### PR TITLE
return empty html document if custom var grafana_graph_disable is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
-## [1.3.6](https://github.com/mikesch-mp/icingaweb2-module-grafana/tree/1.3.6) (2019-09-07)
-[Full Changelog](https://github.com/mikesch-mp/icingaweb2-module-grafana/compare/v1.3.5...1.3.6)
+## [v1.3.6](https://github.com/mikesch-mp/icingaweb2-module-grafana/tree/v1.3.6) (2019-09-07)
+[Full Changelog](https://github.com/mikesch-mp/icingaweb2-module-grafana/compare/v1.3.5...v1.3.6)
 
 **Closed issues:**
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ LICENSE file included in the source package.
 
 ## Support
 
-Join the [Icinga community channels](https://www.icinga.com/community/get-involved/) for questions.
+Join the [Icinga community channels](https://icinga.com/community/) for questions.
 
 ## Requirements
 
-* [Icinga Web 2](https://www.icinga.com/products/icinga-web-2/) (>= 2.4.1)
-* [Grafana](https://grafana.com/) (>= 4.1) **For Grafana 5, dashboard names need to be unique!**
-* [InfluxDB](https://docs.influxdata.com/influxdb/), [Graphite](https://graphiteapp.org) or [PNP](https://docs.pnp4nagios.org/) (untested) as backend for Grafana
-* [PHP](https://www.php.net) **with curl enabled** (for proxy mode)
+* [Icinga Web 2](https://www.icinga.com/products/icinga-web-2/) (>= 2.8.2)
+* [Grafana](https://grafana.com/) (>= 7.0)
+* [InfluxDB](https://docs.influxdata.com/influxdb/) (>= 1.0) [Graphite](https://graphiteapp.org) as backend for Grafana
+* [PHP 7](https://www.php.net) **with curl enabled** (for proxy mode)
 
 ## Documentation
 

--- a/application/controllers/DashboardController.php
+++ b/application/controllers/DashboardController.php
@@ -2,10 +2,13 @@
 
 namespace Icinga\Module\Grafana\Controllers;
 
+use Icinga\Application\Modules\Module;
 use Icinga\Module\Grafana\ProvidedHook\Grapher;
+use Icinga\Module\Grafana\ProvidedHook\Icingadb\IcingadbSupport;
 use Icinga\Module\Monitoring\Object\Host;
 use Icinga\Module\Monitoring\Controller;
 use Icinga\Module\Monitoring\Object\Service;
+use ipl\Web\Url;
 
 class DashboardController extends Controller
 {
@@ -17,6 +20,10 @@ class DashboardController extends Controller
 
     public function indexAction()
     {
+        if (Module::exists('icingadb') && IcingadbSupport::useIcingaDbAsBackend()) {
+            $this->redirectNow(Url::fromPath('grafana/icingadbdashboard')->setQueryString($this->params));
+        }
+
         $this->getTabs()->add('graphs', array(
             'active' => true,
             'label' => $this->translate('Graphs'),

--- a/application/controllers/IcingadbdashboardController.php
+++ b/application/controllers/IcingadbdashboardController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Icinga\Module\Grafana\Controllers;
+
+use Icinga\Exception\NotFoundError;
+use Icinga\Module\Grafana\ProvidedHook\Icingadb\HostDetailExtension;
+use Icinga\Module\Grafana\ProvidedHook\Icingadb\ServiceDetailExtension;
+use Icinga\Module\Grafana\Web\Controller\IcingadbGrafanaController;
+use Icinga\Module\Icingadb\Model\Host;
+use Icinga\Module\Icingadb\Model\Service;
+use ipl\Stdlib\Filter;
+use ipl\Web\Url;
+
+class IcingadbdashboardController extends IcingadbGrafanaController
+{
+    public function init()
+    {
+        $this->assertPermission('grafana/graph');
+        $this->setAutorefreshInterval(15);
+    }
+
+    public function indexAction()
+    {
+        if (! $this->useIcingadbAsBackend) {
+            $this->redirectNow(Url::fromPath('grafana/dashboard')->setQueryString($this->params));
+        }
+
+        $this->getTabs()->add(
+            'graphs',
+            [
+                'active' => true,
+                'label' => $this->translate('Graphs'),
+                'url' => $this->getRequest()->getUrl()
+            ]
+        );
+
+        $hostName = $this->params->getRequired('host');
+        $serviceName = $this->params->get('service');
+
+        if ($serviceName != null) {
+            $query = Service::on($this->getDb());
+            $query->filter(
+                Filter::all(
+                    Filter::equal('service.name', $serviceName),
+                    Filter::equal('host.name', $hostName)
+                )
+            );
+        } else {
+            $query = Host::on($this->getDb());
+            $query->filter(Filter::equal('host.name', $hostName));
+        }
+
+        $this->applyRestrictions($query);
+        $object = $query->first();
+        if ($object === null) {
+            throw new NotFoundError(t('Host or Service not found'));
+        }
+
+        if ($object instanceof Host) {
+            $graph = new HostDetailExtension();
+        } else {
+            $graph = new ServiceDetailExtension();
+        }
+
+        $this->addContent($graph->getPreviewHtml($object));
+    }
+}

--- a/application/controllers/IcingadbdashboardController.php
+++ b/application/controllers/IcingadbdashboardController.php
@@ -38,7 +38,12 @@ class IcingadbdashboardController extends IcingadbGrafanaController
         $serviceName = $this->params->get('service');
 
         if ($serviceName != null) {
-            $query = Service::on($this->getDb());
+            $query = Service::on($this->getDb())->with([
+                'state',
+                'icon_image',
+                'host',
+                'host.state'
+            ]);
             $query->filter(
                 Filter::all(
                     Filter::equal('service.name', $serviceName),
@@ -46,7 +51,7 @@ class IcingadbdashboardController extends IcingadbGrafanaController
                 )
             );
         } else {
-            $query = Host::on($this->getDb());
+            $query = Host::on($this->getDb())->with(['state', 'icon_image']);
             $query->filter(Filter::equal('host.name', $hostName));
         }
 

--- a/application/controllers/IcingadbimgController.php
+++ b/application/controllers/IcingadbimgController.php
@@ -19,7 +19,6 @@ use Icinga\Module\Icingadb\Model\Service;
 use ipl\Stdlib\Filter;
 use ipl\Web\Url;
 
-
 class IcingadbimgController extends IcingadbGrafanaController
 {
     protected $host;
@@ -57,14 +56,13 @@ class IcingadbimgController extends IcingadbGrafanaController
             $this->redirectNow(Url::fromPath('grafana/dashboard')->setQueryString($this->params));
         }
         /* we need at least a host name */
-        if (is_null($this->getParam('host')))
-        {
+        if (is_null($this->getParam('host'))) {
             throw new \Error('No host given!');
         }
 
         /* save timerange from params for later use */
         $this->timerange = $this->hasParam('timerange') ? urldecode($this->getParam('timerange')) : null;
-        if($this->hasParam('timerangeto')) {
+        if ($this->hasParam('timerangeto')) {
             $this->timerangeto = urldecode($this->getParam('timerangeto'));
         } else {
             $this->timerangeto = strpos($this->timerange, '/') ? 'now-' . $this->timerange : "now";
@@ -82,13 +80,16 @@ class IcingadbimgController extends IcingadbGrafanaController
         $this->protocol = $this->myConfig->get('protocol', $this->protocol);
 
         $this->defaultDashboard = $this->myConfig->get('defaultdashboard', $this->defaultDashboard);
-        $this->defaultdashboarduid = $this->myConfig->get('defaultdashboarduid', NULL);
+        $this->defaultdashboarduid = $this->myConfig->get('defaultdashboarduid', null);
         if (is_null($this->defaultdashboarduid)) {
             throw new ConfigurationError(
                 'Usage of Grafana 5 is configured but no UID for default dashboard found!'
             );
         }
-        $this->defaultDashboardPanelId = $this->myConfig->get('defaultdashboardpanelid', $this->defaultDashboardPanelId);
+        $this->defaultDashboardPanelId = $this->myConfig->get(
+            'defaultdashboardpanelid',
+            $this->defaultDashboardPanelId
+        );
         $this->defaultOrgId = $this->myConfig->get('defaultorgid', $this->defaultOrgId);
         $this->grafanaTheme = $this->myConfig->get('theme', $this->grafanaTheme);
         $this->defaultDashboardStore = $this->myConfig->get('defaultdashboardstore', $this->defaultDashboardStore);
@@ -99,7 +100,7 @@ class IcingadbimgController extends IcingadbGrafanaController
         /**
          * Read the global default timerange
          */
-        if($this->timerange == null) {
+        if ($this->timerange == null) {
             $this->timerange = $this->config->get('timerange', $this->timerange);
         }
         /**
@@ -146,7 +147,6 @@ class IcingadbimgController extends IcingadbGrafanaController
                 $this->myAuth = "";
             }
         }
-
     }
 
     public function indexAction()
@@ -159,29 +159,25 @@ class IcingadbimgController extends IcingadbGrafanaController
         $varsFlat
             ->columns(['flatname', 'flatvalue'])
             ->orderBy('flatname');
-        if ($this->hasParam('service') && ! is_null($this->getParam('service')))
-        {
+        if ($this->hasParam('service') && ! is_null($this->getParam('service'))) {
             $service = $this->getServiceObject();
             $this->object = $service;
             $serviceName = $this->object->name;
             $hostName = $this->object->host->name;
-            $varsFlat->filter(Filter::equal('host.id', $this->object->id));
-
         } else {
             $host = $this->getHostObject();
             $this->object = $host;
-            $serviceName = $this->object->checkcommand;
+            $serviceName = $this->object->checkcommand_name;
             $hostName = $this->object->name;
-            $varsFlat->filter(Filter::equal('host.id', $this->object->id));
-
         }
+        $varsFlat->filter(Filter::equal('host.id', $this->object->id));
 
         $this->applyRestrictions($varsFlat);
         $customVars = $this->getDb()->fetchPairs($varsFlat->assembleSelect());
         if (array_key_exists($this->custvarconfig, $customVars) && ! empty($customVars[$this->custvarconfig])) {
             $this->setGraphConf($this->object->customvars[$this->custvarconfig]);
         } else {
-            $this->setGraphConf($serviceName, $this->object->checkcommand);
+            $this->setGraphConf($serviceName, $this->object->checkcommand_name);
         }
 
         if (!empty($this->customVars)) {
@@ -214,7 +210,7 @@ class IcingadbimgController extends IcingadbGrafanaController
         $imageHtml = "";
         $res = $this->getMyimageHtml($serviceName, $hostName, $imageHtml);
         header('Pragma: public');
-        if($this->refresh == "yes") {
+        if ($this->refresh == "yes") {
             header('Pragma: public');
             header("Expires: ".gmdate("D, d M Y H:i:s", time() + $this->cacheTime)." GMT");
             header('Cache-Control: max-age='.$this->cacheTime).', public';
@@ -223,16 +219,15 @@ class IcingadbimgController extends IcingadbGrafanaController
             header('Cache-Control: max-age='. (365*86440));
         }
         header("Content-type: image/png");
-        if (! $res)
-        {
+        if (! $res) {
             // set expire to now and max age to 1 minute
             header("Expires: ".gmdate("D, d M Y H:i:s", time())." GMT");
             header('Cache-Control: max-age='. 120);
-            $string = wordwrap($this->translate('Error'). ': ' . $imageHtml,40,"\n");
+            $string = wordwrap($this->translate('Error'). ': ' . $imageHtml, 40, "\n");
             $lines = explode("\n", $string);
-            $im = @imagecreate ($this->width, $this->height);
-            $background_color = imagecolorallocate ($im, 255, 255, 255); //white background
-            $text_color = imagecolorallocate ($im, 255, 0,0);//black text
+            $im = @imagecreate($this->width, $this->height);
+            $background_color = imagecolorallocate($im, 255, 255, 255); //white background
+            $text_color = imagecolorallocate($im, 255, 0, 0);//black text
             foreach ($lines as $i => $line) {
                 imagestring($im, 5, 0, 5 + $i * 15, $line, $text_color);
             }
@@ -252,7 +247,7 @@ class IcingadbimgController extends IcingadbGrafanaController
 
     private function getHostObject()
     {
-        $query = Host::on($this->getDb());
+        $query = Host::on($this->getDb())->with(['state', 'icon_image']);
         $query->filter(Filter::equal('name', urldecode($this->getParam('host'))));
 
         $this->applyRestrictions($query);
@@ -267,7 +262,12 @@ class IcingadbimgController extends IcingadbGrafanaController
 
     private function getServiceObject()
     {
-        $query = Service::on($this->getDb());
+        $query = Service::on($this->getDb())->with([
+            'state',
+            'icon_image',
+            'host',
+            'host.state'
+        ]);
         $query->filter(Filter::equal('name', $this->getParam('service')));
         $query->filter(Filter::equal('host.name', $this->getParam('host')));
 
@@ -282,28 +282,32 @@ class IcingadbimgController extends IcingadbGrafanaController
         return $service;
     }
 
-    private function setGraphConf($serviceName, $serviceCommand = NULL)
+    private function setGraphConf($serviceName, $serviceCommand = null)
     {
         $graphConfig = Config::module('grafana', 'graphs');
 
-        if ($graphConfig->hasSection(strtok($serviceName, ' ')) && ($graphConfig->hasSection($serviceName) == False)) {
+        if ($graphConfig->hasSection(strtok($serviceName, ' ')) && ($graphConfig->hasSection($serviceName) == false)) {
             $serviceName = strtok($serviceName, ' ');
         }
-        if ($graphConfig->hasSection(strtok($serviceName, ' ')) == False && ($graphConfig->hasSection($serviceName) == False)) {
+
+        if ($graphConfig->hasSection(strtok($serviceName, ' ')) == false
+            && ($graphConfig->hasSection($serviceName) == false)
+        ) {
             $serviceName = $serviceCommand;
-            if($graphConfig->hasSection($serviceCommand) == False && $this->defaultDashboard == 'none') {
-                return NULL;
+            if ($graphConfig->hasSection($serviceCommand) == false && $this->defaultDashboard == 'none') {
+                return null;
             }
         }
 
         $this->dashboard = $graphConfig->get($serviceName, 'dashboard', $this->defaultDashboard);
         $this->dashboarduid = $graphConfig->get($serviceName, 'dashboarduid', $this->defaultdashboarduid);
-        $this->panelId = $this->hasParam('panelid') ? $this->getParam('panelid') : $graphConfig->get($serviceName, 'panelId', $this->defaultDashboardPanelId);
+        $this->panelId = $this->hasParam('panelid') ?
+            $this->getParam('panelid')
+            : $graphConfig->get($serviceName, 'panelId', $this->defaultDashboardPanelId);
         $this->orgId = $graphConfig->get($serviceName, 'orgId', $this->defaultOrgId);
         $this->customVars = $graphConfig->get($serviceName, 'customVars', '');
         $this->height = $graphConfig->get($serviceName, 'height', $this->height);
         $this->width = $graphConfig->get($serviceName, 'width', $this->width);
-
     }
 
     private function getMyimageHtml($serviceName, $hostName, &$imageHtml)
@@ -311,18 +315,21 @@ class IcingadbimgController extends IcingadbGrafanaController
         $imgClass = $this->shadows ? "grafana-img grafana-img-shadows" : "grafana-img";
         // Test whether curl is loaded
         if (extension_loaded('curl') === false) {
-            $imageHtml = $this->translate('CURL extension is missing. Please install CURL for PHP and ensure it is loaded.');
+            $imageHtml = $this->translate('CURL extension is missing.'
+                . ' Please install CURL for PHP and ensure it is loaded.');
             return false;
         }
+
         $this->pngUrl = sprintf(
-            '%s://%s/render/d-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&width=%s&height=%s&theme=%s&from=%s&to=%s',
+            '%s://%s/render/d-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s'
+            . '&width=%s&height=%s&theme=%s&from=%s&to=%s',
             $this->protocol,
             $this->grafanaHost,
             $this->dashboarduid,
             $this->dashboard,
             rawurlencode($hostName),
             rawurlencode($serviceName),
-            rawurlencode($this->object->checkcommand),
+            rawurlencode($this->object->checkcommand_name),
             $this->customVars,
             $this->panelId,
             $this->orgId,
@@ -346,7 +353,10 @@ class IcingadbimgController extends IcingadbGrafanaController
         );
 
         if ($this->authentication == "token") {
-            $curl_opts[CURLOPT_HTTPHEADER] = array('Content-Type: application/json' , "Authorization: Bearer ". $this->apiToken);
+            $curl_opts[CURLOPT_HTTPHEADER] = [
+                'Content-Type: application/json',
+                "Authorization: Bearer ". $this->apiToken
+            ];
         } else {
             $curl_opts[CURLOPT_USERPWD] = "$this->myAuth";
         }
@@ -368,8 +378,13 @@ class IcingadbimgController extends IcingadbGrafanaController
 
         if ($statusCode > 299) {
             $error = @json_decode($res);
-            $imageHtml .= $this->translate('Cannot fetch Grafana graph'). ": " . Util::httpStatusCodeToString($statusCode) .
-                " ". $statusCode .": " . ($error !== null && property_exists($error, 'message') ? $error->message : "");
+            $imageHtml .= $this->translate('Cannot fetch Grafana graph')
+                . ": "
+                . Util::httpStatusCodeToString($statusCode)
+                . " "
+                . $statusCode
+                . ": "
+                . ($error !== null && property_exists($error, 'message') ? $error->message : "");
             return false;
         }
 

--- a/application/controllers/IcingadbshowController.php
+++ b/application/controllers/IcingadbshowController.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: carst
+ * Date: 17.02.2018
+ * Time: 20:09
+ */
+
+namespace Icinga\Module\Grafana\Controllers;
+
+use Icinga\Exception\NotFoundError;
+use Icinga\Module\Grafana\ProvidedHook\Icingadb\HostDetailExtension;
+use Icinga\Module\Grafana\ProvidedHook\Icingadb\ServiceDetailExtension;
+use Icinga\Module\Grafana\Web\Controller\IcingadbGrafanaController;
+use Icinga\Module\Grafana\Web\Widget\PrintAction;
+use Icinga\Module\Icingadb\Model\CustomvarFlat;
+use Icinga\Module\Icingadb\Model\Host;
+use Icinga\Module\Icingadb\Model\Service;
+use Icinga\Module\Grafana\Helpers\Timeranges;
+use Icinga\Application\Config;
+use ipl\Html\HtmlDocument;
+use ipl\Html\HtmlElement;
+use ipl\Html\HtmlString;
+use ipl\Stdlib\Filter;
+use ipl\Web\Url;
+
+class IcingadbshowController extends IcingadbGrafanaController
+{
+    /** @var bool */
+    protected $showFullscreen;
+    protected $host;
+    protected $custvardisable = "grafana_graph_disable";
+
+    public function init()
+    {
+        $this->assertPermission('grafana/showall');
+        $this->view->showFullscreen
+            = $this->showFullscreen
+            = (bool)$this->_helper->layout()->showFullscreen;
+        $this->host = $this->getParam('host');
+        $this->config = Config::module('grafana')->getSection('grafana');
+        /**
+         * Name of the custom varibale to disable graph
+         */
+        $this->custvardisable = ($this->config->get('custvardisable', $this->custvardisable));
+    }
+
+    public function indexAction()
+    {
+        if (! $this->useIcingadbAsBackend) {
+            $this->redirectNow(Url::fromPath('grafana/show')->setQueryString($this->params));
+        }
+        $this->disableAutoRefresh();
+
+        if (!$this->showFullscreen) {
+            $this->getTabs()->add(
+                'graphs',
+                [
+                    'label' => $this->translate('Grafana Graphs'),
+                    'url' => $this->getRequest()->getUrl()
+                ]
+            )->activate('graphs');
+
+            $this->getTabs()->extend(new PrintAction());
+        }
+
+        $this->addControl(
+            HtmlElement::create(
+                'h1',
+                null,
+                sprintf($this->translate('Performance graphs for %s'), $this->host)
+            )
+        );
+
+        // Preserve timerange if selected
+        $parameters = ['host' => $this->host];
+        if ($this->hasParam('timerange')) {
+            $parameters['timerange'] = $this->getParam('timerange');
+        }
+
+        /* The timerange menu */
+        $menu = new Timeranges($parameters, 'grafana/show');
+        $this->addControl(new HtmlString($menu->getTimerangeMenu()));
+
+        /* first host object for host graph */
+        $this->object = $this->getHostObject($this->host);
+        $varsFlat = CustomvarFlat::on($this->getDb());
+        $this->applyRestrictions($varsFlat);
+
+        $varsFlat
+            ->columns(['flatname', 'flatvalue'])
+            ->orderBy('flatname');
+        $varsFlat->filter(Filter::equal('host.id', $this->object->id));
+        $customVars = $this->getDb()->fetchAll($varsFlat->assembleSelect());
+        if ($this->object->perfdata_enabled
+            || !(isset($customVars[$this->custvardisable])
+                && json_decode(strtolower($customVars[$this->custvardisable])) !== false)
+        ) {
+            $object = (new HtmlDocument())
+                ->addHtml(HtmlElement::create('h2', null, $this->object->checkcommand));
+            $this->addContent($object);
+            $this->addContent((new HostDetailExtension())->getPreviewHtml($this->object, true));
+        }
+        /* Get all services for this host */
+        $query = Service::on($this->getDb());
+        $query->filter(Filter::equal('host.name', $this->host));
+
+        $this->applyRestrictions($query);
+
+        foreach ($query as $service) {
+            $this->object = $this->getServiceObject($service->name, $this->host);
+            $varsFlat = CustomvarFlat::on($this->getDb());
+            $this->applyRestrictions($varsFlat);
+
+            $varsFlat
+                ->columns(['flatname', 'flatvalue'])
+                ->orderBy('flatname');
+            $varsFlat->filter(Filter::equal('service.id', $service->id));
+            $customVars = $this->getDb()->fetchAll($varsFlat->assembleSelect());
+            if ($this->object->perfdata_enabled
+                && !(isset($customVars[$this->custvardisable])
+                    && json_decode(strtolower($customVars[$this->custvardisable])) !== false)
+            ) {
+                $object = (new HtmlDocument())
+                    ->addHtml(HtmlElement::create('h2', null, $service->name));
+                $this->addContent($object);
+                $this->addContent((new ServiceDetailExtension())->getPreviewHtml($service, true));
+            }
+        }
+
+        unset($this->object);
+        unset($customVars);
+    }
+
+
+    public function getHostObject($host)
+    {
+        $query = Host::on($this->getDb());
+        $query->filter(Filter::equal('name', $host));
+        $this->applyRestrictions($query);
+        $host = $query->first();
+
+        if ($host === null) {
+            throw new NotFoundError(t('Host not found'));
+        }
+
+        return $host;
+    }
+
+    public function getServiceObject($service, $host)
+    {
+        $query = Service::on($this->getDb());
+
+        $query->filter(Filter::equal('name', $service));
+        $query->filter(Filter::equal('host.name', $host));
+        $this->applyRestrictions($query);
+
+        $service = $query->first();
+
+        if ($service === null) {
+            throw new NotFoundError(t('Service not found'));
+        }
+
+        return $service;
+    }
+}

--- a/application/controllers/IcingadbshowController.php
+++ b/application/controllers/IcingadbshowController.php
@@ -97,12 +97,17 @@ class IcingadbshowController extends IcingadbGrafanaController
                 && json_decode(strtolower($customVars[$this->custvardisable])) !== false)
         ) {
             $object = (new HtmlDocument())
-                ->addHtml(HtmlElement::create('h2', null, $this->object->checkcommand));
+                ->addHtml(HtmlElement::create('h2', null, $this->object->checkcommand_name));
             $this->addContent($object);
             $this->addContent((new HostDetailExtension())->getPreviewHtml($this->object, true));
         }
         /* Get all services for this host */
-        $query = Service::on($this->getDb());
+        $query = Service::on($this->getDb())->with([
+            'state',
+            'icon_image',
+            'host',
+            'host.state'
+        ]);
         $query->filter(Filter::equal('host.name', $this->host));
 
         $this->applyRestrictions($query);
@@ -135,7 +140,7 @@ class IcingadbshowController extends IcingadbGrafanaController
 
     public function getHostObject($host)
     {
-        $query = Host::on($this->getDb());
+        $query = Host::on($this->getDb())->with(['state', 'icon_image']);
         $query->filter(Filter::equal('name', $host));
         $this->applyRestrictions($query);
         $host = $query->first();

--- a/application/controllers/ImgController.php
+++ b/application/controllers/ImgController.php
@@ -196,14 +196,15 @@ class ImgController extends MonitoringAwareController
         $imageHtml = "";
         $res = $this->getMyimageHtml($serviceName, $hostName, $imageHtml);
         header('Pragma: public');
+				/* makes trouble with IcingaDB or php8.1
         if($this->refresh == "yes") {
-            header('Pragma: public');
             header("Expires: ".gmdate("D, d M Y H:i:s", time() + $this->cacheTime)." GMT");
             header('Cache-Control: max-age='.$this->cacheTime).', public';
         } else {
             header("Expires: ".gmdate("D, d M Y H:i:s", time() + 365*86440)." GMT");
             header('Cache-Control: max-age='. (365*86440));
         }
+        */
         header("Content-type: image/png");
         if (! $res)
         {

--- a/application/controllers/ShowController.php
+++ b/application/controllers/ShowController.php
@@ -8,9 +8,12 @@
 
 namespace Icinga\Module\Grafana\Controllers;
 
+use Icinga\Application\Modules\Module;
+use Icinga\Module\Grafana\ProvidedHook\Icingadb\IcingadbSupport;
 use Icinga\Module\Grafana\Web\Controller\MonitoringAwareController;
 use Icinga\Module\Monitoring\Object\Service;
 use Icinga\Module\Monitoring\Object\Host;
+use Icinga\Web\Url;
 use Icinga\Web\Widget\Tab;
 use Icinga\Web\Hook;
 use Icinga\Module\Grafana\Helpers\Timeranges;
@@ -40,6 +43,10 @@ class ShowController extends MonitoringAwareController
 
     public function indexAction()
     {
+        if (Module::exists('icingadb') && IcingadbSupport::useIcingaDbAsBackend()) {
+            $this->redirectNow(Url::fromPath('grafana/icingadbshow')->setQueryString($this->params));
+        }
+
         $this->disableAutoRefresh();
         $this->view->host = $this->host;
 

--- a/library/Grafana/Helpers/Timeranges.php
+++ b/library/Grafana/Helpers/Timeranges.php
@@ -92,7 +92,7 @@ class Timeranges
     private function buildTimerangeMenu($timerange = "", $timerangeto = "")
     {
         $clockIcon = $this->view->qlink('', 'dashboard/new-dashlet',
-            ['url' => 'grafana/dashboard?' . http_build_query($this->urlparams, null, '&', PHP_QUERY_RFC3986)],
+            ['url' => 'grafana/dashboard?' . http_build_query($this->urlparams, "", '&', PHP_QUERY_RFC3986)],
             ['icon' => 'clock', 'title' => 'Add graph to dashboard']);
 
         $menu = '<table class="grafana-table"><tr>';

--- a/library/Grafana/Helpers/Timeranges.php
+++ b/library/Grafana/Helpers/Timeranges.php
@@ -92,7 +92,7 @@ class Timeranges
     private function buildTimerangeMenu($timerange = "", $timerangeto = "")
     {
         $clockIcon = $this->view->qlink('', 'dashboard/new-dashlet',
-            ['url' => 'grafana/dashboard?' . http_build_query($this->urlparams, null, '&', PHP_QUERY_RFC3986)],
+            ['url' => 'grafana/dashboard?' . http_build_query($this->urlparams, '', '&', PHP_QUERY_RFC3986)],
             ['icon' => 'clock', 'title' => 'Add graph to dashboard']);
 
         $menu = '<table class="grafana-table"><tr>';

--- a/library/Grafana/ProvidedHook/Icingadb/HostActions.php
+++ b/library/Grafana/ProvidedHook/Icingadb/HostActions.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Icinga\Module\Grafana\ProvidedHook\Icingadb;
+
+use Icinga\Application\Config;
+use Icinga\Authentication\Auth;
+use Icinga\Module\Icingadb\Hook\HostActionsHook;
+use Icinga\Module\Icingadb\Model\Host;
+use ipl\Web\Url;
+use ipl\Web\Widget\Link;
+
+class HostActions extends HostActionsHook
+{
+    protected $defaultTimerange = '1w/w';
+
+    public function getActionsForObject(Host $host): array
+    {
+        if (! Auth::getInstance()->hasPermission('grafana/showall')) {
+            return [];
+        }
+
+        $config = Config::module('grafana')->getSection('grafana');
+        $timerange = $config->get('timerangeAll', $this->defaultTimerange);
+
+        return [
+            new Link(
+                t('Show all graphs'),
+                Url::fromPath('grafana/show', ['host' => $host->name, 'timerange' => $timerange]),
+                ['target' => '_next', 'icon' => 'gauge']
+            )
+        ];
+    }
+}

--- a/library/Grafana/ProvidedHook/Icingadb/HostDetailExtension.php
+++ b/library/Grafana/ProvidedHook/Icingadb/HostDetailExtension.php
@@ -6,7 +6,6 @@ use Icinga\Module\Icingadb\Hook\HostDetailExtensionHook;
 use Icinga\Module\Icingadb\Model\Host;
 use ipl\Html\ValidHtml;
 
-
 class HostDetailExtension extends HostDetailExtensionHook
 {
     use IcingaDbGrapher;

--- a/library/Grafana/ProvidedHook/Icingadb/HostDetailExtension.php
+++ b/library/Grafana/ProvidedHook/Icingadb/HostDetailExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Icinga\Module\Grafana\ProvidedHook\Icingadb;
+
+use Icinga\Module\Icingadb\Hook\HostDetailExtensionHook;
+use Icinga\Module\Icingadb\Model\Host;
+use ipl\Html\ValidHtml;
+
+
+class HostDetailExtension extends HostDetailExtensionHook
+{
+    use IcingaDbGrapher;
+
+    public function getHtmlForObject(Host $host): ValidHtml
+    {
+        $this->object = $host;
+        return $this->getPreviewHtml($host);
+    }
+}

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -263,7 +263,7 @@ trait IcingaDbGrapher
                     'grafana/icingadbimg',
                     [
                     'host' => rawurlencode($hostName),
-                    'service' => rawurlencode($serviceName),
+                    'service' => $serviceName,
                     'panelid' => $this->panelId,
                     'timerange' => urlencode($this->timerange),
                     'timerangeto' => urlencode($this->timerangeto),

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -1,0 +1,765 @@
+<?php
+
+namespace Icinga\Module\Grafana\ProvidedHook\Icingadb;
+
+use Icinga\Application\Config;
+use Icinga\Application\Icinga;
+use Icinga\Authentication\Auth;
+use Icinga\Exception\ConfigurationError;
+use Icinga\Module\Grafana\Helpers\Timeranges;
+use Icinga\Module\Grafana\Helpers\Util;
+use Icinga\Module\Icingadb\Common\Auth as IcingaDbAuth;
+use Icinga\Module\Icingadb\Common\Database;
+use Icinga\Module\Icingadb\Common\Links;
+use Icinga\Module\Icingadb\Model\CustomvarFlat;
+use Icinga\Module\Icingadb\Model\Host;
+use Icinga\Module\Icingadb\Model\Service;
+use ipl\Html\Html;
+use ipl\Html\HtmlDocument;
+use ipl\Html\HtmlElement;
+use ipl\Html\HtmlString;
+use ipl\Orm\Model;
+use ipl\Stdlib\Filter;
+use ipl\Web\Url;
+use ipl\Web\Widget\Link;
+
+trait IcingaDbGrapher
+{
+    use Database;
+    use IcingaDbAuth;
+
+    protected $config;
+    protected $graphConfig;
+    protected $auth;
+    protected $authentication;
+    protected $grafanaHost = null;
+    protected $grafanaTheme = 'light';
+    protected $protocol = "http";
+    protected $usePublic = "no";
+    protected $publicHost = null;
+    protected $publicProtocol = "http";
+    protected $timerange = "6h";
+    protected $timerangeto = "now";
+    protected $username = null;
+    protected $password = null;
+    protected $apiToken = null;
+    protected $width = 640;
+    protected $height = 280;
+    protected $enableLink = true;
+    protected $defaultDashboard = "icinga2-default";
+    protected $defaultDashboardPanelId = "1";
+    protected $defaultOrgId = "1";
+    protected $shadows = false;
+    protected $defaultDashboardStore = "db";
+    protected $dataSource = null;
+    protected $accessMode = "proxy";
+    protected $proxyTimeout = "5";
+    protected $refresh = "no";
+    protected $title;  //"<h2>Performance Graph</h2>";
+    protected $custvardisable = "grafana_graph_disable";
+    protected $custvarconfig = "grafana_graph_config";
+    protected $repeatable = "no";
+    protected $numberMetrics = "1";
+    protected $debug = false;
+    protected $SSLVerifyPeer = false;
+    protected $SSLVerifyHost = "0";
+    protected $cacheTime = 300;
+    protected $grafanaVersion = "0";
+    protected $defaultdashboarduid;
+    protected $object;
+
+    protected function init()
+    {
+        $this->title = Html::tag("h2", "Performance Graph");
+        $this->permission = Auth::getInstance();
+        $this->config = Config::module('grafana')->getSection('grafana');
+        $this->grafanaVersion = $this->config->get('version', $this->grafanaVersion);
+        $this->grafanaHost = $this->config->get('host', $this->grafanaHost);
+        if ($this->grafanaHost === null) {
+            throw new ConfigurationError(
+                'No Grafana host configured!'
+            );
+        }
+
+        $this->protocol = $this->config->get('protocol', $this->protocol);
+        $this->enableLink = $this->config->get('enableLink', $this->enableLink);
+        if ($this->enableLink === "yes" && $this->permission->hasPermission('grafana/enablelink')) {
+            $this->usePublic = $this->config->get('usepublic', $this->usePublic);
+            if ($this->usePublic === "yes") {
+                $this->publicHost = $this->config->get('publichost', $this->publicHost);
+                if ($this->publicHost === null) {
+                    throw new ConfigurationError(
+                        'No Grafana public host configured!'
+                    );
+                }
+                $this->publicProtocol = $this->config->get('publicprotocol', $this->publicProtocol);
+            } else {
+                $this->publicHost = $this->grafanaHost;
+                $this->publicProtocol = $this->protocol;
+            }
+        }
+
+        // Confid needed for Grafana
+        $this->defaultDashboard = $this->config->get('defaultdashboard', $this->defaultDashboard);
+        $this->defaultdashboarduid = $this->config->get('defaultdashboarduid', null);
+        if (is_null($this->defaultdashboarduid)) {
+            throw new ConfigurationError(
+                'no UID for default dashboard found!'
+            );
+        }
+
+        $this->defaultDashboardPanelId = $this->config->get(
+            'defaultdashboardpanelid',
+            $this->defaultDashboardPanelId
+        );
+        $this->defaultOrgId = $this->config->get('defaultorgid', $this->defaultOrgId);
+        $this->grafanaTheme = $this->config->get('theme', $this->grafanaTheme);
+        $this->height = $this->config->get('height', $this->height);
+        $this->width = $this->config->get('width', $this->width);
+
+        $this->accessMode = $this->config->get('accessmode', $this->accessMode);
+        $this->proxyTimeout = $this->config->get('proxytimeout', $this->proxyTimeout);
+        /**
+         * Read the global default timerange
+         */
+        $this->timerange = $this->config->get('timerange', $this->timerange);
+        /**
+         * Datasource needed to regex special chars
+         */
+        $this->dataSource = $this->config->get('datasource', $this->dataSource);
+        /**
+         * Display shadows around graph
+         */
+        $this->shadows = $this->config->get('shadows', $this->shadows);
+        /**
+         * Name of the custom varibale to disable graph
+         */
+        $this->custvardisable = ($this->config->get('custvardisable', $this->custvardisable));
+        /**
+         * Name of the custom varibale for graph config
+         */
+        $this->custvarconfig = ($this->config->get('custvarconfig', $this->custvarconfig));
+
+        /**
+         * Show some debug informations?
+         */
+        $this->debug = ($this->config->get('debug', $this->debug));
+        /**
+         * Verify the certificate's name against host
+         */
+        $this->SSLVerifyHost = ($this->config->get('ssl_verifyhost', $this->SSLVerifyHost));
+        /**
+         * Verify the peer's SSL certificate
+         */
+        $this->SSLVerifyPeer = ($this->config->get('ssl_verifypeer', $this->SSLVerifyPeer));
+
+        /**
+         * Username & Password or token
+         */
+
+        $this->apiToken = $this->config->get('apitoken', $this->apiToken);
+        $this->authentication = $this->config->get('authentication');
+        if ($this->apiToken === null && $this->authentication === "token") {
+            throw new ConfigurationError(
+                'API token usage configured, but no token given!'
+            );
+        } else {
+            $this->username = $this->config->get('username', $this->username);
+            $this->password = $this->config->get('password', $this->password);
+            if ($this->username !== null) {
+                if ($this->password !== null) {
+                    $this->auth = $this->username . ":" . $this->password;
+                } else {
+                    $this->auth = $this->username;
+                }
+            } else {
+                $this->auth = "";
+            }
+        }
+    }
+
+    public function has(Model $object): bool
+    {
+        if (($object instanceof Host) || ($object instanceof Service)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private function getGraphConfigOption($section, $option, $default = null)
+    {
+        $value = $this->graphConfig->get($section, $option, $default);
+        if (empty($value)) {
+            return $default;
+        }
+        return $value;
+    }
+
+
+    /**
+     * @param $serviceName
+     * @param $serviceCommand
+     * @return $this|null
+     */
+    private function getGraphConf($serviceName, $serviceCommand = null): ?self
+    {
+        $this->graphConfig = Config::module('grafana', 'graphs');
+
+        if ($this->graphConfig->hasSection(strtok($serviceName, ' '))
+            && ($this->graphConfig->hasSection($serviceName) === false)) {
+            $serviceName = strtok($serviceName, ' ');
+        }
+        if ($this->graphConfig->hasSection(strtok($serviceName, ' ')) === false
+            && ($this->graphConfig->hasSection($serviceName) === false)) {
+            $serviceName = $serviceCommand;
+            if ($this->graphConfig->hasSection($serviceCommand) === false && $this->defaultDashboard === 'none') {
+                return null;
+            }
+        }
+
+        $this->dashboard = $this->getGraphConfigOption($serviceName, 'dashboard', $this->defaultDashboard);
+        $this->dashboarduid = $this->getGraphConfigOption(
+            $serviceName,
+            'dashboarduid',
+            $this->defaultdashboarduid
+        );
+        $this->panelId = $this->getGraphConfigOption($serviceName, 'panelId', $this->defaultDashboardPanelId);
+        $this->orgId = $this->getGraphConfigOption($serviceName, 'orgId', $this->defaultOrgId);
+        $this->customVars = $this->getGraphConfigOption($serviceName, 'customVars', '');
+
+        if (Url::fromRequest()->hasParam('tr-from') && Url::fromRequest()->hasParam('tr-to')) {
+            $this->timerange = urldecode(Url::fromRequest()->getParam('tr-from'));
+            $this->timerangeto = urldecode(Url::fromRequest()->getParam('tr-to'));
+        } else {
+            $this->timerange = Url::fromRequest()->hasParam('timerange') ?
+                'now-' . urldecode(Url::fromRequest()->getParam('timerange')) :
+                'now-' . $this->getGraphConfigOption($serviceName, 'timerange', $this->timerange);
+            $this->timerangeto = strpos($this->timerange, '/') ? $this->timerange : $this->timerangeto;
+        }
+
+        $this->height = $this->getGraphConfigOption($serviceName, 'height', $this->height);
+        $this->width = $this->getGraphConfigOption($serviceName, 'width', $this->width);
+        $this->repeatable = $this->getGraphConfigOption($serviceName, 'repeatable', $this->repeatable);
+        $this->numberMetrics = $this->getGraphConfigOption($serviceName, 'nmetrics', $this->numberMetrics);
+
+        return $this;
+    }
+
+    /**
+     * @param $serviceName
+     * @param $hostName
+     * @param HtmlDocument $previewHtml
+     * @return bool
+     * @throws \Icinga\Exception\ProgrammingError
+     */
+    private function getMyPreviewHtml($serviceName, $hostName, HtmlDocument $previewHtml): bool
+    {
+        $imgClass = $this->shadows ? "grafana-img grafana-img-shadows" : "grafana-img";
+
+        if ($this->accessMode === "indirectproxy") {
+            if ($this->object instanceof Service) {
+                $this->pngUrl = Url::frompath(
+                    'grafana/icingadbimg',
+                    [
+                    'host' => rawurlencode($hostName),
+                    'service' => rawurlencode($serviceName),
+                    'panelid' => $this->panelId,
+                    'timerange' => urlencode($this->timerange),
+                    'timerangeto' => urlencode($this->timerangeto),
+                    'cachetime' => $this->cacheTime]
+                );
+            } else {
+                $this->pngUrl = Url::frompath(
+                    'grafana/icingadbimg',
+                    [
+                    'host' => rawurlencode($hostName),
+                    'panelid' => $this->panelId,
+                    'timerange' => urlencode($this->timerange),
+                    'timerangeto' => urlencode($this->timerangeto),
+                    'cachetime' => $this->cacheTime
+                    ]
+                );
+            }
+
+            $imgProps = [
+                "src" => Icinga::app()->getViewRenderer()->view->serverUrl() . $this->pngUrl,
+                "alt" => $serviceName,
+                "width" => $this->width,
+                "height" => $this->height,
+                "class" => $imgClass
+            ];
+
+            $imgHtml = Html::tag('div', ["style" => "min-height: $this->height" . "px"]);
+            $imgHtml->addHtml(
+                Html::tag(
+                    'img',
+                    $imgProps
+                )
+            );
+
+            $previewHtml->add($imgHtml);
+        } elseif ($this->accessMode === "iframe") {
+            $iFramesrc = sprintf(
+                "%s://%s/d-solo/%s/%s?" .
+                "var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&theme=%s&from=%s&to=%s",
+                $this->protocol,
+                $this->grafanaHost,
+                $this->dashboarduid,
+                $this->dashboard,
+                rawurlencode($hostName),
+                rawurlencode($serviceName),
+                rawurlencode($this->object->checkcommand_name),
+                $this->customVars,
+                $this->panelId,
+                $this->orgId,
+                $this->grafanaTheme,
+                urlencode($this->timerange),
+                urlencode($this->timerangeto)
+            );
+
+            $iframeHtml = Html::tag(
+                'iframe',
+                [
+                    "src" => $iFramesrc,
+                    "alt" => rawurlencode($serviceName),
+                    "height" => $this->height,
+                    "style" => "width: 100%"
+                ]
+            );
+
+            $previewHtml->add($iframeHtml);
+        }
+        return true;
+    }
+
+    /**
+     * @param Model $object
+     * @param $report
+     * @return false|HtmlElement
+     * @throws ConfigurationError
+     * @throws \Icinga\Exception\ProgrammingError
+     */
+    public function getPreviewHtml(Model $object, $report = false)
+    {
+        $this->cacheTime = $object->state->next_check - $object->state->last_update;
+
+        if ($object instanceof Host) {
+            $serviceName = $object->checkcommand_name;
+            $hostName = $object->name;
+            $link = Links::host($object);
+        } elseif ($object instanceof Service) {
+            $serviceName = $object->name;
+            $hostName = $object->host->name;
+            $link = Links::service($object, $object->host);
+        }
+
+        $parameters['timerange'] = $this->timerange;
+        $db = $this->getDb();
+
+        $varsFlat = CustomvarFlat::on($db);
+        $this->applyRestrictions($varsFlat);
+
+        $varsFlat
+            ->columns(['flatname', 'flatvalue'])
+            ->orderBy('flatname');
+
+        if ($object instanceof Host) {
+            $varsFlat->filter(Filter::equal('host.id', $object->id));
+        } else {
+            $varsFlat->filter(Filter::equal('service.id', $object->id));
+        }
+
+        $customvars = $this->getDb()->fetchPairs($varsFlat->assembleSelect());
+
+        if (array_key_exists($this->custvarconfig, $customvars)
+            && !empty($customvars[$this->custvarconfig])) {
+            $graphConfiguation = $this->getGraphConf($customvars[$this->custvarconfig]);
+        } else {
+            $graphConfiguation = $this->getGraphConf($serviceName, $object->checkcommand_name);
+        }
+        if ($graphConfiguation === null) {
+            return false;
+        }
+
+        if ($this->repeatable === "yes") {
+            $panelEnd =  ($this->panelId - 1) +
+                intval(substr_count($object->state->performance_data, '=') / $this->numberMetrics);
+            $this->panelId = implode(
+                ',',
+                range($this->panelId, $panelEnd)
+            );
+        }
+
+        // replace special chars for graphite
+        if ($this->dataSource === "graphite" && $this->accessMode !== "indirectproxy") {
+            $serviceName = Util::graphiteReplace($serviceName);
+            $hostName = Util::graphiteReplace($hostName);
+        }
+
+        if (! empty($this->customVars)) {
+            // replace template to customVars from Icinga2
+            foreach ($customvars as $k => $v) {
+                $search[] = "\$$k\$";
+                $replace[] = is_string($v) ? $v : null;
+                $this->customVars = str_replace($search, $replace, $this->customVars);
+            }
+
+            // urlencoded values
+            $customVars = "";
+
+            foreach (preg_split('/\&/', $this->customVars, -1, PREG_SPLIT_NO_EMPTY) as $param) {
+                $arr = explode("=", $param);
+                if (preg_match('/^\$.*\$$/', $arr[1])) {
+                    $arr[1] = '';
+                }
+                if ($this->dataSource === "graphite") {
+                    $arr[1] = Util::graphiteReplace($arr[1]);
+                }
+                $customVars .= '&' . $arr[0] . '=' . rawurlencode($arr[1]);
+            }
+            $this->customVars = $customVars;
+        }
+
+        $return_html = new HtmlDocument();
+
+        // Hide menu if in reporting or compact mode
+        $menu = "";
+
+        if ($report === false && ! Icinga::app()->getViewRenderer()->view->compact) {
+            $timeranges = new Timeranges($parameters, $link);
+            $menu = new HtmlString($timeranges->getTimerangeMenu($this->timerange, $this->timerangeto));
+        } else {
+            $this->title = '';
+        }
+
+        foreach (explode(',', $this->panelId) as $panelid) {
+            $html = new HtmlDocument();
+            $this->panelId = $panelid;
+
+            //image value will be returned as reference
+            $previewHtml = new HtmlDocument();
+            $res = $this->getMyPreviewHtml($serviceName, $hostName, $previewHtml);
+            //do not render URLs on error or if disabled
+            if (! $res
+                || $this->enableLink === "no"
+                || ! $this->permission->hasPermission('grafana/enablelink')) {
+                $html->addHtml($previewHtml);
+            } else {
+                $urlFormat = "%s://%s/d/%s/%s" .
+                "?var-hostname=%s&var-service=%s&var-command=%s%s&from=%s&to=%s&orgId=%s&viewPanel=%s";
+
+                $url = sprintf(
+                    $urlFormat,
+                    $this->publicProtocol,
+                    $this->publicHost,
+                    $this->dashboarduid,
+                    $this->dashboard,
+                    rawurlencode(($this->dataSource === "graphite" ? Util::graphiteReplace($hostName) : $hostName)),
+                    rawurlencode(
+                        ($this->dataSource === "graphite" ? Util::graphiteReplace($serviceName) : $serviceName)
+                    ),
+                    rawurlencode($object->checkcommand_name),
+                    $this->customVars,
+                    urlencode($this->timerange),
+                    urlencode($this->timerangeto),
+                    $this->orgId,
+                    $this->panelId
+                );
+
+                $link = new Link($previewHtml, $url, ["target" => "_blank"]);
+
+                $html->add($link);
+            }
+
+            $return_html->add($html);
+        }
+
+        if ($this->debug && $this->permission->hasPermission('grafana/debug') && $report === false) {
+            if ($this->accessMode === "indirectproxy") {
+                $usedUrl = $this->pngUrl;
+            } else {
+                $usedUrl = preg_replace('/.*?src\s*=\s*[\'\"](.*?)[\'\"].*/', "$1", $previewHtml);
+            }
+
+            if ($this->accessMode === "iframe") {
+                $this->height = "100%";
+            }
+
+            $return_html->addHtml(HtmlElement::create("h2", null, "Performance Graph Debug"));
+
+            $grafanaTable = HtmlElement::create("table", ["class" => "name-value-table"]);
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Access mode"),
+                        Html::tag('td', null, $this->accessMode)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Authentication type"),
+                        Html::tag('td', null, $this->authentication)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Protocol"),
+                        Html::tag('td', null, $this->protocol)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Grafan Host"),
+                        Html::tag('td', null, $this->grafanaHost)
+                    ]
+                )
+            );
+
+            if ($this->grafanaVersion === "1") {
+                $grafanaTable->add(
+                    Html::tag(
+                        'tr',
+                        null,
+                        [
+                            Html::tag('th', null, "Dashboard UID"),
+                            Html::tag('td', null, $this->dashboarduid)
+                        ]
+                    )
+                );
+            } else {
+                $grafanaTable->add(
+                    Html::tag(
+                        'tr',
+                        null,
+                        [
+                            Html::tag('th', null, "Dashboard Store"),
+                            Html::tag('td', null, $this->defaultDashboardStore)
+                        ]
+                    )
+                );
+            }
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Dashboard Name"),
+                        Html::tag('td', null, $this->dashboard)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Panel ID"),
+                        Html::tag('td', null, $this->panelId)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Organization ID"),
+                        Html::tag('td', null, $this->orgId)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Organization ID"),
+                        Html::tag('td', null, $this->orgId)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Theme"),
+                        Html::tag('td', null, $this->grafanaTheme)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Timerange"),
+                        Html::tag('td', null, $this->timerange)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Timerangeto"),
+                        Html::tag('td', null, $this->timerangeto)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Height"),
+                        Html::tag('td', null, $this->height)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Width"),
+                        Html::tag('td', null, $this->width)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Custom Variables"),
+                        Html::tag('td', null, $this->customVars)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Graph URL"),
+                        Html::tag('td', null, $usedUrl)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Disable graph custom variable"),
+                        Html::tag('td', null, $this->custvardisable)
+                    ]
+                )
+            );
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Graph config custom variable"),
+                        Html::tag('td', null, $this->custvarconfig)
+                    ]
+                )
+            );
+
+            if (isset($customvars[$this->custvarconfig])) {
+                $grafanaTable->add(
+                    Html::tag(
+                        'tr',
+                        null,
+                        [
+                            Html::tag('th', null, $this->custvarconfig),
+                            Html::tag('td', null, $customvars[$this->custvarconfig])
+                        ]
+                    )
+                );
+            }
+
+            $grafanaTable->add(
+                Html::tag(
+                    'tr',
+                    null,
+                    [
+                        Html::tag('th', null, "Shadows"),
+                        Html::tag('td', null, (($this->shadows) ? 'Yes' : 'No'))
+                    ]
+                )
+            );
+
+            if ($this->accessMode === "proxy") {
+                $grafanaTable->add(
+                    Html::tag(
+                        'tr',
+                        null,
+                        [
+                            Html::tag('th', null, "SSL Verify Peer"),
+                            Html::tag('td', null, (($this->SSLVerifyPeer) ? 'Yes' : 'No'))
+                        ]
+                    )
+                );
+
+                $grafanaTable->add(
+                    Html::tag(
+                        'tr',
+                        null,
+                        [
+                            Html::tag('th', null, "SSL Verify Host"),
+                            Html::tag('td', null, (($this->SSLVerifyHost) ? 'Yes' : 'No'))
+                        ]
+                    )
+                );
+            }
+
+            $return_html->add($grafanaTable);
+        }
+
+        $htmlForObject = HtmlElement::create(
+            "div",
+            ["class" => "icinga-module module-grafana", "style" => "display: inline-block;"]
+        );
+
+        $htmlForObject->add($this->title);
+        $htmlForObject->add($menu);
+        $htmlForObject->add($return_html);
+        return $htmlForObject;
+    }
+}

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -267,7 +267,8 @@ trait IcingaDbGrapher
                     'panelid' => $this->panelId,
                     'timerange' => urlencode($this->timerange),
                     'timerangeto' => urlencode($this->timerangeto),
-                    'cachetime' => $this->cacheTime]
+                    'cachetime' => $this->cacheTime
+                    ]
                 );
             } else {
                 $this->pngUrl = Url::frompath(
@@ -342,7 +343,8 @@ trait IcingaDbGrapher
      */
     public function getPreviewHtml(Model $object, $report = false)
     {
-        $this->cacheTime = $object->state->next_check - $object->state->last_update;
+        $this->object = $object;
+        $this->cacheTime = round($object->state->next_check - $object->state->last_update);
 
         if ($object instanceof Host) {
             $serviceName = $object->checkcommand_name;

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -374,6 +374,15 @@ trait IcingaDbGrapher
 
         $customvars = $this->getDb()->fetchPairs($varsFlat->assembleSelect());
 
+        // enable_perfdata = true ?  || disablevar == true
+        if (!$this->object->perfdata_enabled
+            || (( isset($customvars[$this->custvardisable])
+                && json_decode(strtolower($customvars[$this->custvardisable])) !== false))
+            ) {
+                $return_html = new HtmlDocument();
+                return $return_html;
+            }
+
         if (array_key_exists($this->custvarconfig, $customvars)
             && !empty($customvars[$this->custvarconfig])) {
             $graphConfiguation = $this->getGraphConf($customvars[$this->custvarconfig]);

--- a/library/Grafana/ProvidedHook/Icingadb/IcingadbSupport.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingadbSupport.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Icinga\Module\Grafana\ProvidedHook\Icingadb;
+
+use Icinga\Module\Icingadb\Hook\IcingadbSupportHook;
+
+class IcingadbSupport extends IcingadbSupportHook
+{
+
+}

--- a/library/Grafana/ProvidedHook/Icingadb/ServiceDetailExtension.php
+++ b/library/Grafana/ProvidedHook/Icingadb/ServiceDetailExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Icinga\Module\Grafana\ProvidedHook\Icingadb;
+
+use Icinga\Application\Icinga;
+
+use Icinga\Module\Graphite\Util\InternalProcessTracker as IPT;
+use Icinga\Module\Graphite\Web\Controller\TimeRangePickerTrait;
+use Icinga\Module\Graphite\Web\Widget\Graphs;
+use Icinga\Module\Icingadb\Hook\ServiceDetailExtensionHook;
+use Icinga\Module\Icingadb\Model\Service;
+use ipl\Html\Html;
+use ipl\Html\HtmlString;
+use ipl\Html\ValidHtml;
+use ipl\Orm\Model;
+
+class ServiceDetailExtension extends ServiceDetailExtensionHook
+{
+    use IcingaDbGrapher;
+
+    public function getHtmlForObject(Service $service): ValidHtml
+    {
+        $this->object = $service;
+        return $this->getPreviewHtml($service);
+    }
+}

--- a/library/Grafana/Web/Controller/IcingadbGrafanaController.php
+++ b/library/Grafana/Web/Controller/IcingadbGrafanaController.php
@@ -1,0 +1,25 @@
+<?php
+
+/* Icinga Graphite Web | (c) 2022 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Grafana\Web\Controller;
+
+use Icinga\Application\Modules\Module;
+use Icinga\Module\Graphite\ProvidedHook\Icingadb\IcingadbSupport;
+use Icinga\Module\Icingadb\Common\Auth;
+use Icinga\Module\Icingadb\Common\Database;
+use ipl\Web\Compat\CompatController;
+
+class IcingadbGrafanaController extends CompatController
+{
+    use Auth;
+    use Database;
+
+    /** @var bool Whether to use icingadb as the backend */
+    protected $useIcingadbAsBackend;
+
+    protected function moduleInit()
+    {
+        $this->useIcingadbAsBackend = Module::exists('icingadb') && IcingadbSupport::useIcingaDbAsBackend();
+    }
+}

--- a/library/Grafana/Web/Controller/IcingadbGrafanaController.php
+++ b/library/Grafana/Web/Controller/IcingadbGrafanaController.php
@@ -5,7 +5,7 @@
 namespace Icinga\Module\Grafana\Web\Controller;
 
 use Icinga\Application\Modules\Module;
-use Icinga\Module\Graphite\ProvidedHook\Icingadb\IcingadbSupport;
+use Icinga\Module\Grafana\ProvidedHook\Icingadb\IcingadbSupport;
 use Icinga\Module\Icingadb\Common\Auth;
 use Icinga\Module\Icingadb\Common\Database;
 use ipl\Web\Compat\CompatController;

--- a/library/Grafana/Web/Widget/PrintAction.php
+++ b/library/Grafana/Web/Widget/PrintAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Icinga\Module\Grafana\Web\Widget;
+
+use Icinga\Web\Url;
+use Icinga\Web\Widget\Tabextension\Tabextension;
+use Icinga\Web\Widget\Tabs;
+
+/**
+ * Tabextension that allows to print the current page
+ *
+ * Displayed as a dropdown field in the tabs
+ */
+class PrintAction implements Tabextension
+{
+    /**
+     * Applies the dashboard actions to the provided tabset
+     *
+     * @param   Tabs $tabs The tabs object to extend with
+     */
+    public function apply(Tabs $tabs)
+    {
+        $tabs->addAsDropdown(
+            'print',
+            [
+                'icon'      => 'print',
+                'target'=> '_blank',
+                'label'     => t('Print'),
+                'url'       => (htmlspecialchars_decode(Url::fromRequest()->getAbsoluteUrl())). '&showFullscreen',
+            ]
+        );
+    }
+}

--- a/module.info
+++ b/module.info
@@ -1,6 +1,7 @@
 Name: Grafana
 Version: 1.4.2
-Depends: monitoring
+Requires:
+  Modules: monitoring, icingadb (>= 1.0.0)
 Description: Grafana - A perfdata visualisation module
  Shows Grafana graphs for captured metrics.
 

--- a/module.info
+++ b/module.info
@@ -1,6 +1,7 @@
 Name: Grafana
-Version: 1.4.2
-Depends: monitoring
+Version: 1.4.3
+Requires:
+  Modules: monitoring (>=2.9.0), icingadb (>=1.0.0)
 Description: Grafana - A perfdata visualisation module
  Shows Grafana graphs for captured metrics.
 

--- a/run.php
+++ b/run.php
@@ -2,3 +2,7 @@
 
 $this->provideHook('grapher');
 $this->provideHook('monitoring/HostActions');
+$this->provideHook('icingadb/HostActions');
+$this->provideHook('icingadb/IcingadbSupport');
+$this->provideHook('icingadb/HostDetailExtension');
+$this->provideHook('icingadb/ServiceDetailExtension');


### PR DESCRIPTION
if the custom variable grafana_graph_disable is set, an empty HTML document is returned so that no graph is displayed in the web interface.

Also changed `'service' => rawurlencode($serviceName)` to `'service' => $serviceName` so that the Services link is created correctly with spaces in the name, as noted by @fabbricalox here:
https://github.com/Mikesch-mp/icingaweb2-module-grafana/pull/288#issuecomment-1278986305