### PR TITLE
Update IcingaDbGrapher.php

### DIFF
--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -264,7 +264,7 @@ trait IcingaDbGrapher
                     'grafana/icingadbimg',
                     [
                     'host' => rawurlencode($hostName),
-                    'service' => rawurlencode($serviceName),
+                    'service' => $serviceName,
                     'panelid' => $this->panelId,
                     'timerange' => urlencode($this->timerange),
                     'timerangeto' => urlencode($this->timerangeto),


### PR DESCRIPTION
removed URL Encode on serviceName Var to prevent double Encoding